### PR TITLE
Security Fix: correct flagged web link

### DIFF
--- a/_posts/2019-02-14-nahomcon19.md
+++ b/_posts/2019-02-14-nahomcon19.md
@@ -3,12 +3,12 @@ title: "Inaugural NAHOMCon19 Coming to San Diego"
 categories: event
 ---
 
-To all computational scientists, mathematicians, scientists, and engineers interested in high-order methods and PDEs: Several institutions have joined together to organize the inaugural [North American High Order Methods Conference (NAHOMCon19)](https://www.nahomcon19.sdsu.edu/). The conference will be held in San Diego in the summer of 2019 and will focus on the many developments in high-order discretizations and applications taking place in North America.
+To all computational scientists, mathematicians, scientists, and engineers interested in high-order methods and PDEs: Several institutions have joined together to organize the inaugural [North American High Order Methods Conference (NAHOMCon19)](https://nahomcon19.sdsu.edu/). The conference will be held in San Diego in the summer of 2019 and will focus on the many developments in high-order discretizations and applications taking place in North America.
 
 The DOE co-design Center for Efficient Exascale Discretizations (CEED) is pleased to participate in the conference. CEED is a partnership between two U.S. DOE laboratories (Livermore & Argonne) and five universities in support of the [Exascale Computing Project](https://www.exascaleproject.org/exascale-computing-project/).
 
 Learn more:
-- [NAHOMCon19 registration](https://www.nahomcon19.sdsu.edu/)
+- [NAHOMCon19 registration](https://nahomcon19.sdsu.edu/)
 - [CEED website](https://ceed.exascaleproject.org/)
 - [CEED software catalog](https://ceed.exascaleproject.org/software/)
 - [CEED GitHub repo](https://github.com/ceed/)


### PR DESCRIPTION
The NAHOMCon19 links in this document was flagged by the NIST site scan because the domain name for the site does not exist.  This PR corrects the URLs with the proper domain name.